### PR TITLE
Your explanation is almost right, but let's fine-tune it to match the…

### DIFF
--- a/PS-Sprint-1/README.md
+++ b/PS-Sprint-1/README.md
@@ -23,7 +23,7 @@
    **Example**:  
    Input: `year = 2020`  
    Output: `Leap Year`  
-   Explanation: 2020 is divisible by 4 but not by 100, or it is divisible by 400, so it is a leap year.  
+   Explanation: A year is a leap year if it is divisible by 4 but not by 100, unless it is also divisible by 400.  
 
 4. **Calculating Armstrong Numbers**  
    **Difficulty**: Easy  


### PR DESCRIPTION
… exact leap year rules and make it clearer.

2020 is a leap year because:

It is divisible by 4 → ✅

It is not divisible by 100 → ✅

So, it satisfies the rule:
➤ A year is a leap year if it is divisible by 4 but not by 100 unless it is also divisible by 400.